### PR TITLE
Add check to avoid null pointer exception

### DIFF
--- a/src/scheduler.cc
+++ b/src/scheduler.cc
@@ -42,10 +42,12 @@ void Sched::add(pToDo todo)
 	{
 		if ((i != sched.end()) && ((*i)->sched() == todo->sched()))
 		{
-			for (; ((*i)->sched() == todo->sched()); i++);
-			i--;
-			todo->schedPosition() = (*i)->schedPosition() + 1;
-			i++;
+			if (i != sched.begin()){
+				for (; ((*i)->sched() == todo->sched()); i++);
+				i--;
+				todo->schedPosition() = (*i)->schedPosition() + 1;
+				i++;
+			}
 		}
 		else
 		{


### PR DESCRIPTION
A bug can cause a segmentation fault. 
Add task ABC
Add task DEF
Set schedule of ABC to today.
Set schedule of DEF to today. This should cause a segmentation fault as the access after the i-- should point to an illegal address in this case.  Bug raised in issue https://github.com/meskio/tudu/issues/10